### PR TITLE
Updating the workflow and contributing documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,15 +1,7 @@
-# Local workflow
+![BlueFinch Checkout](../assets/logo.svg)
 
-When you install the module it will be able to read from the generated `dist` but for making change it is best to use the `watch` functionality.
+# BlueFinch Checkout - Contributing
 
-Turn on support for vite watch in the admin panel or by using magerun
-- `BlueFinch -> Checkout -> General -> Enable local developer vite watch mode = yes`
-- `n98-magerun config:store:set bluefinchcommerce_checkout/general/enable_local_developer_vite_watch_mode=1`
+We welcome contributions to any of the BlueFinch Checkout modules.
 
-```bash
-cd view/frontend/web/js/checkout/ # or view/adminhtml/web/js/checkout/
-npm ci
-npm run build-watch
-```
-
-This will populate `view/frontend/web/js/checkout/dist-dev` for use, allowing you to make changes and have them quickly visible on the frontend.
+Please refer to the [BlueFinch Checkout contributing guidelines](https://github.com/BlueFinchCommerce/module-checkout/blob/main/.github/CONTRIBUTING.md) that apply to both the core module and any extension modules, such as this one.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,44 @@
 
 This module serves as an example of how to create a custom extension for the BlueFinch Checkout module.
 
+## Requirements
+
+- Magento 2.4.6 or higher
+- Node 16 or higher (for development purposes only)
+- Latest version of BlueFinch Checkout
+
+## Installation
+
+Ensure you have installed the latest version of BlueFinch Checkout, which can be found here, [BlueFinch Checkout](https://github.com/bluefinchcommerce/module-checkout).
+
+For information about a module installation in Adobe Commerce, see [Enable or disable modules](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/tutorials/manage-modules).
+
+Remember to clear any appropriate caches.
+
 ## Getting Started
 Please refer to the [BlueFinch Checkout Modules docs](https://github.com/BlueFinchCommerce/module-checkout), specifically the [Custom extension guide](https://github.com/BlueFinchCommerce/module-checkout/blob/main/docs/Extensions.md) and the [how to create a checkout extension module](https://github.com/BlueFinchCommerce/module-checkout/blob/main/docs/how-to-create-a-checkout-extension-module.md) document.
+
+## Local frontend development workflow
+
+Please refer to the local frontend development workflow section of the [BlueFinch Checkout contributing guidelines](https://github.com/BlueFinchCommerce/module-checkout/blob/main/.github/CONTRIBUTING.md), that applies to all BlueFinch Checkout extension modules, such as this one.
+
+## CircleCi
+
+CircleCi is a tool for us to use to allow for tested to be run on our modules before they are deployed.
+
+This template comes with EsLint and PHPStan.
+
+You can add more tests to this if you need to.
+
+
+### Testing your module locally
+
+You can test CircleCi before you push your code.
+
+To do this you need to install circleci locally.
+
+``` brew install circleci```
+
+Then once this has been installed in the main directory of your package then.
+
+```circleci local execute```


### PR DESCRIPTION
Removing the FE workflow documentation from the contributing doc and adding references to the same information on the core checkout module to reduce duplication for future documentation amends.

Updating the readme with generic module information.